### PR TITLE
fix: exclude CHANGELOG to md linter

### DIFF
--- a/.github/workflows/markdown-linter.yml
+++ b/.github/workflows/markdown-linter.yml
@@ -11,3 +11,5 @@ jobs:
 
       - name: Markdown Lint
         uses: ruzickap/action-my-markdown-linter@v1
+        with:
+          exclude: CHANGELOG.md


### PR DESCRIPTION
I use `release-please` to manage CHANGELOG. Its template doesn't fit to the default linter rules and trigger many warnings.

I skip this file for now.